### PR TITLE
Supporting description for errors

### DIFF
--- a/syntax.md
+++ b/syntax.md
@@ -75,6 +75,7 @@ described [here](https://creativecommons.org/licenses/by/4.0/)
             - [Out parameter key-value: `arraysize`](#out-parameter-key-value-arraysize)
             - [Out parameter key-value: `range`](#out-parameter-key-value-range)
         - [Methods list object: `error`](#methods-list-object-error)
+            - [Error parameter key-value: `description`](#error-parameter-key-value-description)
             - [Error parameter key-value: `datatype`](#error-parameter-key-value-datatype)
             - [Error parameter key-value: `arraysize`](#error-parameter-key-value-arraysize)
             - [Error parameter key-value: `range`](#error-parameter-key-value-range)
@@ -1484,7 +1485,7 @@ chapter for details on how to specify ranges.
 |:-------------------|:------------------------------|
 | **Hosted by**      | `methods` list object         |
 | **Mandatory Keys** | `datatype`                    |
-| **Optional keys**  | `range`, `arraysize`, `range` |
+| **Optional keys**  | `range`, `arraysize`, `description` |
 
 
 The optional `error` element defines an error value to return. The
@@ -1549,6 +1550,15 @@ Specifies the legal range for the value.
 Please see [value range specification](#value-range-specification)
 chapter for details on how to specify ranges.
 
+
+### Error parameter key-value: `description`
+|                  |               |
+|:-----------------|:--------------|
+| **YAML Type**    | string        |
+| **Mandatory**    | No            |
+| **Lark grammar** | [YAML string] |
+
+Specifies a description of how the errors shall be used.
 
 ----------------------
 


### PR DESCRIPTION
To be able to give additional guidelines on how to use the errors.

Intention could e.g. be to give a description like below with recommendations on what each error mean in the context of this particular operation

```
error:
          - description: |
              "ok" - requested seat movement has been executed successfully
              "invalid_argument" - any argument out of range supported by vehicle
              "not_found" - addressed seat not available/existing
              "other" - internal error in implementation
              It is assumed that this operation does not need unique resources and returns immediately,
              so no need to support "interrupted" and "busy" as errors.
            datatype: .stdvsc.error_t
            range: $ in_set("ok", "invalid_argument", "not_found", "other")
```