### PR TITLE
Adapting examples on removal of type for properties

### DIFF
--- a/comfort-service.yml
+++ b/comfort-service.yml
@@ -292,7 +292,7 @@ namespaces:
 
         error:
           - description: |
-              "ok" - requested seat movement has been executed successfully
+              "ok" - current position of selected seat has been returned
               "invalid_argument" - any argument out of range supported by vehicle
               "not_found" - addressed seat not available/existing
               "other" - internal error in implementation
@@ -362,12 +362,13 @@ namespaces:
     # across one or more subscribers. They are equivalent to
     # MQTT topics or SOME/IP fields.
     #
+    # In VSC all properties are considered to be read/write
+    #
     # TODO: Define relationship, rules, and semantics
     #       between properties and VSS signals.
     #       See vss_integration_proposal.yml for one solution.
     #
     properties:
-      - name: a_property # Will this be acceptable?
+      - name: a_property
         description: A signal
-        type: attribute # or sensor.
-        datatype: uint8 # Native datatypes only?
+        datatype: uint8

--- a/vss_integration_proposal.yml
+++ b/vss_integration_proposal.yml
@@ -10,7 +10,10 @@
 # A proposal for how we can translate VSS signals to properties.
 #
 # Each branch is a namespace, and signals are defined as properties within those
-# namespaces
+# namespaces. As VSC considers all properties as readable and writeable there is no possibility to translate the VSS
+# type (i.e. attribute, sensor or actuator) into Yaml. That does instead need to be managed by access rights in VSC
+# implementations. No client shall e.g. have access right to write VIN, and even if they would the result would be
+# the same - any attempt on writing should result in an error indicating "not supported"
 
 
 # From VSS :
@@ -40,7 +43,6 @@ namespaces:
         properties:
           - name: VIN
             description: 17-character Vehicle Identification Number (VIN) as defined by ISO 3779
-            type: attribute
             datatype: string # VSS should have same native types as VSC
 
 


### PR DESCRIPTION
With current syntax we have now way to specify if a property is readable/writeable, i.e. corresponds to attribute/sensor/actuator in VSS. This PR aligns examples and conversion proposal to that.

Related to #30 