### PR TITLE
comfort-service: Adjust to current impl. in- etc.

### DIFF
--- a/comfort-service.yml
+++ b/comfort-service.yml
@@ -43,7 +43,7 @@ includes:
 namespaces:
   - name: seats
     description: Seat interface and datatypes.
-    
+
     # Defines all structs hosted by the `seats` namespace.
     # Standard structs can be defind, using either native types, typedefs,
     # or other (nested) structs.
@@ -157,8 +157,8 @@ namespaces:
         datatype: movement_t
         description: |
           The relative movement of a seat component
-          
-          
+
+
       - name: percent_float_t
         datatype: float
         min: 0
@@ -220,7 +220,7 @@ namespaces:
         description: |
           Set the desired seat position
 
-        in:
+        input:
           - name: seat
             description: |
               The desired seat position
@@ -245,7 +245,7 @@ namespaces:
         #
         #  Argument can be of any native type, enum, struct, or typedef.
         #
-        in:
+        input:
           - name: seat
             description: |
               The seat location to change
@@ -274,7 +274,7 @@ namespaces:
         description: |
           Get the current position of the seat
 
-        in:
+        input:
           - name: row
             description: |
               The desired seat row to query, front 1 and +1 toward rear
@@ -284,7 +284,7 @@ namespaces:
               The desired seat index to query,  1 left most (as seen looking forward), +1 toward right
             datatype: uint8
 
-        out:
+        output:
           - name: seat
             description: |
               The seat state that was requested
@@ -318,7 +318,7 @@ namespaces:
       - name: seat_moving
         description: |
           The event of a seat beginning movement
-        in:
+        input:
           - name: status
             description: |
               The movement status, moving (1), not moving (0)
@@ -339,7 +339,7 @@ namespaces:
       - name: passenger_present
         description: |
           When the seat passenger status changes
-        in:
+        input:
           - name: status
             description: |
               The status of seat passenger, passenger (1), no passenger (0)


### PR DESCRIPTION
We currently have a mismatch in the example service files and the
implementation. There are additional modifications of the spec
in the pipe (and then vsc-tools and examples accordingly)
but for now it just needs to sync up.